### PR TITLE
Make constructor function optional.

### DIFF
--- a/inherits.js
+++ b/inherits.js
@@ -17,6 +17,7 @@ function inherits (c, p, proto) {
   })
   c.prototype = Object.create(p.prototype, e)
   c.super = p
+  return c
 }
 
 //function Child () {


### PR DESCRIPTION
If no constructor is passed in, generate a default one that
applies the parent constructor. Allows usage like:

```
var Foo = inherits(Bar, { ... })
```
