### PR TITLE
inherits_browser: Add AMD support wrapper.

### DIFF
--- a/inherits_browser.js
+++ b/inherits_browser.js
@@ -1,3 +1,5 @@
+(function (module) { 'use strict';
+
 if (typeof Object.create === 'function') {
   // implementation from standard node.js 'util' module
   module.exports = function inherits(ctor, superCtor) {
@@ -21,3 +23,8 @@ if (typeof Object.create === 'function') {
     ctor.prototype.constructor = ctor
   }
 }
+
+  if (('function' === typeof define) && define.amd) {
+    define(Object.bind(null, module.exports));
+  }
+}('undefined' === typeof module ? {} : module));


### PR DESCRIPTION
Broken indentation is to keep the diff small, won't lint anyway.
